### PR TITLE
header.html: Remove contribute tab from header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,9 +12,6 @@
 				<a class="navbar-item" href="{{ "/quick-start/" | absolute_url }}">
 					Getting Started
 				</a>
-				<a class="navbar-item" href="https://github.com/filebrowser/filebrowser/blob/master/CONTRIBUTING.md">
-					Contribute
-				</a>
 			</div>
 		</div>
 	</nav>


### PR DESCRIPTION
I think it's wise to remove the contribute tab from the header while
the doc is still on the TODO list.