### PR TITLE
Update docker image name

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -116,7 +116,7 @@ layout: default
           </span>
         </div>
         <p>
-          File Browser can be easily installed using <a href="https://www.docker.com/">Docker</a> with <code>docker pull hacdias/filebrowser</code>.
+          File Browser can be easily installed using <a href="https://www.docker.com/">Docker</a> with <code>docker pull filebrowser/filebrowser</code>.
         </p>
       </div>
 


### PR DESCRIPTION
I would even propose to change to url of the Docker link to https://hub.docker.com/r/filebrowser/filebrowser/ . I found myself visiting that to check tags / documentation of the docker image itself.