### PR TITLE
feat: supports mirror usage and add the README back

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# filebrowser/get
+
+https://filebrowser.org/installation
+
+```sh
+# Windows
+iwr -useb https://raw.githubusercontent.com/filebrowser/get/master/get.ps1 | iex
+filebrowser -r /path/to/your/files
+
+# Unix
+curl -fsSL https://raw.githubusercontent.com/filebrowser/get/master/get.sh | bash
+filebrowser -r /path/to/your/files
+
+# If you are in trouble with networking issues,
+# here is an example to work with mirrors:
+export RELEASE_MIRROR='https://gh.api.99988866.xyz/https://github.com'
+curl -fsSL https://raw.gitmirror.com/filebrowser/get/master/get.sh | bash
+filebrowser -r /path/to/your/files
+```

--- a/get.ps1
+++ b/get.ps1
@@ -24,7 +24,14 @@ function Install-FileManager {
 	}
 
 	$file = "windows-$arch-filebrowser.zip"
-	$url = "https://github.com/filebrowser/filebrowser/releases/download/$tag/$file"
+
+	# Support env.RELEASE_MIRROR such as `https://gh.api.99988866.xyz/https://github.com`
+	$release_base = "https://github.com"
+	if ($env:RELEASE_MIRROR) {
+		$release_base = $env:RELEASE_MIRROR
+	}
+	$url = "$release_base/filebrowser/filebrowser/releases/download/$tag/$file"
+
 	$temp =  New-TemporaryFile
 	$folder = "${env:ProgramFiles}\filebrowser"
 

--- a/get.sh
+++ b/get.sh
@@ -108,7 +108,9 @@ install_filemanager()
 	
 	filemanager_file="${filemanager_os}-$filemanager_arch-filebrowser$filemanager_dl_ext"
 	filemanager_tag="$(${net_getter}  https://api.github.com/repos/filebrowser/filebrowser/releases/latest | grep -o '"tag_name": ".*"' | sed 's/"//g' | sed 's/tag_name: //g')"
-	filemanager_url="https://github.com/filebrowser/filebrowser/releases/download/$filemanager_tag/$filemanager_file"
+
+	# Support env.RELEASE_MIRROR such as `https://gh.api.99988866.xyz/https://github.com`
+	filemanager_url="${RELEASE_MIRROR:-https://github.com}/filebrowser/filebrowser/releases/download/$filemanager_tag/$filemanager_file"
 	echo "$filemanager_url"
 
 	# Use $PREFIX for compatibility with Termux on Android


### PR DESCRIPTION
```sh
# Windows
iwr -useb https://raw.githubusercontent.com/filebrowser/get/master/get.ps1 | iex
filebrowser -r /path/to/your/files

# Unix
curl -fsSL https://raw.githubusercontent.com/filebrowser/get/master/get.sh | bash
filebrowser -r /path/to/your/files

# If you are in trouble with networking issues,
# here is an example to work with mirrors:
export RELEASE_MIRROR='https://gh.api.99988866.xyz/https://github.com'
curl -fsSL https://raw.gitmirror.com/filebrowser/get/master/get.sh | bash
filebrowser -r /path/to/your/files
```

<img width="960" alt="image" src="https://github.com/user-attachments/assets/3ec84c17-ba9e-4f45-9a27-553801c1645f">
